### PR TITLE
High-level interface to 1-d minimization

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -16,11 +16,9 @@ jobs:
         uses: actions/cache@v2
         with:
           path: |
-            gsl/dll/x64/Debug/gsl.dll
-            gsl/dll/x64/Debug/gsl.lib
-            gsl/dll/x64/Debug/cblas.dll
-            gsl/dll/x64/Debug/cblas.lib
-          key: x64-Debug-bbf6741a0759a2468c2aa40c501f9cf99b04b427
+            gsl/lib/x64/Debug/gsl.lib
+            gsl/lib/x64/Debug/cblas.lib
+          key: static-x64-Debug-bbf6741a0759a2468c2aa40c501f9cf99b04b427
       - name: Checkout GSL
         if: steps.cache-gsl.outputs.cache-hit != 'true'
         uses: actions/checkout@v2
@@ -37,12 +35,10 @@ jobs:
           cd gsl
           cd build.vc
           msbuild gslhdrs/gslhdrs.vcxproj /p:Configuration=Debug /p:Platform=x64
-          msbuild gsl.dll.sln /p:Configuration=Debug /p:Platform=x64
+          msbuild gsl.lib.sln /p:Configuration=Debug /p:Platform=x64
       - name: copy GSL libraries
         run: |
-          cd gsl/dll/x64/Debug
-          copy cblas.dll ../../../..
-          copy gsl.dll ../../../..
+          cd gsl/lib/x64/Debug
           copy cblas.lib D:\a\_temp\crystal-nightly-false-undefined\bin\lib
           copy gsl.lib D:\a\_temp\crystal-nightly-false-undefined\bin\lib
       - run: crystal spec

--- a/spec/min_spec.cr
+++ b/spec/min_spec.cr
@@ -1,0 +1,33 @@
+require "./spec_helper"
+
+describe GSL do
+  describe "One Dimensional Minimization" do
+    it "performs minimization using high-level interface" do
+      xm, fm = GSL::Min.find_min(0, 6, 1e-6) do |x|
+        Math.cos(x)
+      end
+      xm.should be_close Math::PI, 1e-6
+    end
+
+    it "use guess parameter to avoid bracketing search" do
+      xm, fm = GSL::Min.find_min(-2, 10, 1e-6, guess: -0.5) do |x|
+        x**4
+      end
+      xm.should be_close 0.0, 1e-6
+    end
+
+    it "finds correct minimum even when middle of interval isn't lower than bounds" do
+      xm, fm = GSL::Min.find_min(-2, 10, 1e-6) do |x|
+        x**4
+      end
+      xm.should be_close 0.0, 1e-6
+    end
+
+    it "have enough precision with guess from example" do
+      xm, fm = GSL::Min.find_min(0, 6, 1e-6, guess: 2) do |x|
+        Math.cos(x)
+      end
+      xm.should be_close Math::PI, 1e-6
+    end
+  end
+end

--- a/spec/min_spec.cr
+++ b/spec/min_spec.cr
@@ -29,5 +29,13 @@ describe GSL do
       end
       xm.should be_close Math::PI, 1e-6
     end
+
+    it "works correctly when target function raises" do
+      expect_raises(Exception) do
+        GSL::Min.find_min(0, 6, 1e-6, guess: 2) do |x|
+          raise Exception.new("incorrect value")
+        end
+      end
+    end
   end
 end

--- a/src/gsl/base/error.cr
+++ b/src/gsl/base/error.cr
@@ -5,4 +5,4 @@ class NonIdenticalHistograms < Exception
 end
 
 class IterationsLimitExceeded < Exception
-end 
+end

--- a/src/gsl/base/error.cr
+++ b/src/gsl/base/error.cr
@@ -3,3 +3,6 @@ end
 
 class NonIdenticalHistograms < Exception
 end
+
+class IterationsLimitExceeded < Exception
+end 

--- a/src/gsl/base/function.cr
+++ b/src/gsl/base/function.cr
@@ -1,0 +1,25 @@
+module GSL
+  alias Function = (Float64 -> Float64)
+
+  def self.wrap_function(function : Function)
+    result = uninitialized LibGSL::Gsl_function
+    if function.closure?
+      box = Box.box(function)
+      # (LibC::Double, Void* -> LibC::Double)
+      result.function = ->(x : Float64, data : Void*) do
+        Box(Function).unbox(data).call(x)
+      end
+      result.params = box # no need to keep reference to `box` as `result` holds it.
+    else
+      result.params = function.pointer
+      result.function = ->(x : Float64, data : Void*) do
+        Function.new(data, Pointer(Void).null).call(x)
+      end
+    end
+    result
+  end
+
+  def self.wrap_function(&function : Function)
+    wrap_function(function)
+  end
+end

--- a/src/gsl/base/function.cr
+++ b/src/gsl/base/function.cr
@@ -1,6 +1,8 @@
 module GSL
   alias Function = (Float64 -> Float64)
 
+  # wraps user supplied function (can be closured) to the `LibGSL::Gsl_Function` structure.
+  # note that if you pass resulting function to some C code, you have to keep reference somewhere so it won't be garbage collected.
   def self.wrap_function(function : Function)
     result = uninitialized LibGSL::Gsl_function
     if function.closure?

--- a/src/gsl/base/libgsl.cr
+++ b/src/gsl/base/libgsl.cr
@@ -3869,6 +3869,7 @@ lib LibGSL
   fun gsl_min_fminimizer_free(s : Gsl_min_fminimizer*)
   fun gsl_min_fminimizer_set(s : Gsl_min_fminimizer*, f : Gsl_function*, x_minimum : LibC::Double, x_lower : LibC::Double, x_upper : LibC::Double) : LibC::Int
   fun gsl_min_fminimizer_set_with_values(s : Gsl_min_fminimizer*, f : Gsl_function*, x_minimum : LibC::Double, f_minimum : LibC::Double, x_lower : LibC::Double, f_lower : LibC::Double, x_upper : LibC::Double, f_upper : LibC::Double) : LibC::Int
+  @[Raises]
   fun gsl_min_fminimizer_iterate(s : Gsl_min_fminimizer*) : LibC::Int
   fun gsl_min_fminimizer_name(s : Gsl_min_fminimizer*) : LibC::Char*
   fun gsl_min_fminimizer_x_minimum(s : Gsl_min_fminimizer*) : LibC::Double

--- a/src/gsl/maths/optimization/find_bracket.cr
+++ b/src/gsl/maths/optimization/find_bracket.cr
@@ -1,0 +1,66 @@
+# this is a Crystal translation of gsl/min/bracketing.c
+# with patch proposed in http://savannah.gnu.org/bugs/?45053
+
+# TODO - move somewhere?
+private GOLDEN               =              0.3819660
+private GSL_SQRT_DBL_EPSILON = 1.4901161193847656e-08
+
+module GSL::Min
+  def self.min_find_bracket(f : GSL::Function, x_minimum : LibC::Double*, f_minimum : LibC::Double*, x_lower : LibC::Double*, f_lower : LibC::Double*, x_upper : LibC::Double*, f_upper : LibC::Double*, eval_max : Int32) : LibGSL::Code
+    f_left = f_lower.value
+    f_right = f_upper.value
+    f_center = f_left
+    x_left = x_lower.value
+    x_right = x_upper.value
+    x_center = x_left
+    nb_eval = 0
+    if f_right >= f_left
+      x_center = (x_right - x_left) * GOLDEN + x_left
+      nb_eval += 1
+      f_center = f.call(x_center)
+    else
+      x_center = (x_right - x_left) * (1 - GOLDEN) + x_left
+      nb_eval += 1
+      f_center = f.call(x_center)
+    end
+    loop do
+      if f_center < f_left
+        if f_center < f_right
+          x_lower.value = x_left
+          x_upper.value = x_right
+          x_minimum.value = x_center
+          f_lower.value = f_left
+          f_upper.value = f_right
+          f_minimum.value = f_center
+          return LibGSL::Code::GSL_SUCCESS
+        elsif f_center > f_right
+          x_left = x_center
+          f_left = f_center
+          x_center = (x_right - x_left) * (1 - GOLDEN) + x_left
+          nb_eval += 1
+          f_center = f.call(x_center)
+        else # /* f_center == f_right */
+          x_right = x_center
+          f_right = f_center
+          x_center = (x_right - x_left) * GOLDEN + x_left
+          nb_eval += 1
+          f_center = f.call(x_center)
+        end
+      else # /* f_center >= f_left */
+        x_right = x_center
+        f_right = f_center
+        x_center = (x_right - x_left) * GOLDEN + x_left
+        nb_eval += 1
+        f_center = f.call(x_center)
+      end
+      break unless nb_eval < eval_max && (x_right - x_left) > GSL_SQRT_DBL_EPSILON * ((x_right + x_left) * 0.5) + GSL_SQRT_DBL_EPSILON
+    end
+    x_lower.value = x_left
+    x_upper.value = x_right
+    x_minimum.value = x_center
+    f_lower.value = f_left
+    f_upper.value = f_right
+    f_minimum.value = f_center
+    return LibGSL::Code::GSL_FAILURE
+  end
+end

--- a/src/gsl/maths/optimization/min.cr
+++ b/src/gsl/maths/optimization/min.cr
@@ -27,14 +27,15 @@ module GSL::Min
 
   # High-level interface to minimizer. Finds minimum of function f between `x_lower` and `x_upper`.
   # `eps` - required absolute precision
-  # `algorithm` - minimization algorithm to be used
+  # `algorithm` - minimization algorithm to be used. By default either `Brent` (if `guess` is present) or `QuadGolden` (othrwise) is used.
   # `max_iter` - maximum number of function evaluations, used to stop iterating when solution doesn't converge
   # `guess` - initial guess of a root value that can speed up search. If present, f(guess) < f(x_lower) and f(guess) < f(x_upper) should hold.
   # returns nil if number of iterations = max_iter is exceeded
   # returns {x_min, f_min} tuple if precision = eps achieved
   def self.find_min?(x_lower : Float64, x_upper : Float64, eps : Float64 = 1e-9, *,
-                     algorithm : GSL::Min::Type = GSL::Min::Type::Brent,
+                     algorithm : GSL::Min::Type? = nil,
                      max_iter = 1000, guess = nil, &f : GSL::Function)
+    algorithm = guess ? GSL::Min::Type::Brent : GSL::Min::Type::QuadGolden
     raw = LibGSL.gsl_min_fminimizer_alloc(algorithm.to_unsafe)
     function = GSL.wrap_function(f)
     if guess
@@ -71,7 +72,7 @@ module GSL::Min
   # raises IterationsLimitExceeded if number of iterations = max_iter is exceeded
   # returns {x_min, f_min} tuple if precision = eps achieved
   def self.find_min(x_lower : Float64, x_upper : Float64, eps : Float64,
-                    algorithm : GSL::Min::Type = GSL::Min::Type::Brent,
+                    algorithm : GSL::Min::Type? = nil,
                     max_iter = 1000, guess = nil, &f : GSL::Function)
     find_min?(x_lower, x_upper, eps, algorithm: algorithm, max_iter: max_iter, guess: guess, &f) || raise IterationsLimitExceeded.new("find_min didn't converge")
   end

--- a/src/gsl/maths/optimization/min.cr
+++ b/src/gsl/maths/optimization/min.cr
@@ -25,8 +25,11 @@ module GSL::Min
     end
   end
 
-  # High-level interface to minimizer. Finds minimum of function f between x_lower and x_upper.
-  # algorithm - minimization algorithm to be used
+  # High-level interface to minimizer. Finds minimum of function f between `x_lower` and `x_upper`.
+  # `eps` - required absolute precision
+  # `algorithm` - minimization algorithm to be used
+  # `max_iter` - maximum number of function evaluations, used to stop iterating when solution doesn't converge
+  # `guess` - initial guess of a root value that can speed up search. If present, f(guess) < f(x_lower) and f(guess) < f(x_upper) should hold.
   # returns nil if number of iterations = max_iter is exceeded
   # returns {x_min, f_min} tuple if precision = eps achieved
   def self.find_min?(x_lower : Float64, x_upper : Float64, eps : Float64 = 1e-9, *,
@@ -60,8 +63,11 @@ module GSL::Min
     result
   end
 
-  # High-level interface to minimizer. Finds minimum of function f between x_lower and x_upper.
-  # algorithm - minimization algorithm to be used
+  # High-level interface to minimizer. Finds minimum of function f between `x_lower` and `x_upper`.
+  # `eps` - required absolute precision
+  # `algorithm` - minimization algorithm to be used
+  # `max_iter` - maximum number of function evaluations, used to stop iterating when solution doesn't converge
+  # `guess` - initial guess of a root value that can speed up search. If present, f(guess) < f(x_lower) and f(guess) < f(x_upper) should hold.
   # raises IterationsLimitExceeded if number of iterations = max_iter is exceeded
   # returns {x_min, f_min} tuple if precision = eps achieved
   def self.find_min(x_lower : Float64, x_upper : Float64, eps : Float64,

--- a/src/gsl/maths/optimization/min.cr
+++ b/src/gsl/maths/optimization/min.cr
@@ -29,7 +29,7 @@ module GSL::Min
   # algorithm - minimization algorithm to be used
   # returns nil if number of iterations = max_iter is exceeded
   # returns {x_min, f_min} tuple if precision = eps achieved
-  def self.find_min?(x_lower : Float64, x_upper : Float64, eps : Float64, *,
+  def self.find_min?(x_lower : Float64, x_upper : Float64, eps : Float64 = 1e-9, *,
                      algorithm : GSL::Min::Type = GSL::Min::Type::Brent,
                      max_iter = 1000, guess = nil, &f : GSL::Function)
     raw = LibGSL.gsl_min_fminimizer_alloc(algorithm.to_unsafe)

--- a/src/gsl/maths/optimization/min.cr
+++ b/src/gsl/maths/optimization/min.cr
@@ -9,6 +9,17 @@ module GSL::Min
     Brent
     QuadGolden
 
+    def to_unsafe
+      case self
+      in .golden_section?
+        LibGSL.gsl_min_fminimizer_goldensection
+      in .brent?
+        LibGSL.gsl_min_fminimizer_brent
+      in .quad_golden?
+        LibGSL.gsl_min_fminimizer_quad_golden
+      end
+    end
+
     def to_s
       String.new(LibGSL.gsl_min_fminimizer_name(to_unsafe))
     end
@@ -21,15 +32,7 @@ module GSL::Min
   def self.find_min?(x_lower : Float64, x_upper : Float64, eps : Float64, *,
                      algorithm : GSL::Min::Type = GSL::Min::Type::Brent,
                      max_iter = 1000, guess = nil, &f : GSL::Function)
-    algo = case algorithm
-           in .golden_section?
-             LibGSL.gsl_min_fminimizer_goldensection
-           in .brent?
-             LibGSL.gsl_min_fminimizer_brent
-           in .quad_golden?
-             LibGSL.gsl_min_fminimizer_quad_golden
-           end
-    raw = LibGSL.gsl_min_fminimizer_alloc(algo)
+    raw = LibGSL.gsl_min_fminimizer_alloc(algorithm.to_unsafe)
     function = GSL.wrap_function(f)
     if guess
       LibGSL.gsl_min_fminimizer_set(raw, pointerof(function), guess, x_lower, x_upper)

--- a/src/gsl/maths/optimization/min.cr
+++ b/src/gsl/maths/optimization/min.cr
@@ -1,0 +1,69 @@
+require "../../base/*"
+require "./find_bracket"
+
+private GSL_SQRT_DBL_EPSILON = 1.4901161193847656e-08
+
+module GSL::Min
+  enum Type
+    GoldenSection
+    Brent
+    QuadGolden
+
+    def to_s
+      String.new(LibGSL.gsl_min_fminimizer_name(to_unsafe))
+    end
+  end
+
+  # High-level interface to minimizer. Finds minimum of function f between x_lower and x_upper.
+  # algorithm - minimization algorithm to be used
+  # returns nil if number of iterations = max_iter is exceeded
+  # returns {x_min, f_min} tuple if precision = eps achieved
+  def self.find_min?(x_lower : Float64, x_upper : Float64, eps : Float64, *,
+                     algorithm : GSL::Min::Type = GSL::Min::Type::Brent,
+                     max_iter = 1000, guess = nil, &f : GSL::Function)
+    algo = case algorithm
+           in .golden_section?
+             LibGSL.gsl_min_fminimizer_goldensection
+           in .brent?
+             LibGSL.gsl_min_fminimizer_brent
+           in .quad_golden?
+             LibGSL.gsl_min_fminimizer_quad_golden
+           end
+    raw = LibGSL.gsl_min_fminimizer_alloc(algo)
+    function = GSL.wrap_function(f)
+    if guess
+      LibGSL.gsl_min_fminimizer_set(raw, pointerof(function), guess, x_lower, x_upper)
+    else
+      f_lower = f.call(x_lower)
+      f_upper = f.call(x_upper)
+      x_min = x_lower
+      f_min = f_lower
+      # LibGSL.gsl_min_find_bracket(pointerof(function), pointerof(x_min), pointerof(f_min), pointerof(x_lower), pointerof(f_lower), pointerof(x_upper), pointerof(f_upper), max_iter//2)
+      result = GSL::Min.min_find_bracket(f, pointerof(x_min), pointerof(f_min), pointerof(x_lower), pointerof(f_lower), pointerof(x_upper), pointerof(f_upper), max_iter//2)
+      LibGSL.gsl_min_fminimizer_set_with_values(raw, pointerof(function),
+        x_min, f_min, x_lower, f_lower, x_upper, f_upper)
+    end
+    ok = false
+    max_iter.times do
+      LibGSL.gsl_min_fminimizer_iterate(raw)
+      if LibGSL::Code.new(LibGSL.gsl_min_test_interval(x_lower, x_upper, eps, 0.0)) == LibGSL::Code::GSL_SUCCESS
+        ok = true
+        break
+      end
+    end
+    ok = ok || (raw.value.f_upper - raw.value.f_minimum < GSL_SQRT_DBL_EPSILON)
+    result = ok ? {raw.value.x_minimum, raw.value.f_minimum} : nil
+    LibGSL.gsl_min_fminimizer_free(raw)
+    result
+  end
+
+  # High-level interface to minimizer. Finds minimum of function f between x_lower and x_upper.
+  # algorithm - minimization algorithm to be used
+  # raises IterationsLimitExceeded if number of iterations = max_iter is exceeded
+  # returns {x_min, f_min} tuple if precision = eps achieved
+  def self.find_min(x_lower : Float64, x_upper : Float64, eps : Float64,
+                    algorithm : GSL::Min::Type = GSL::Min::Type::Brent,
+                    max_iter = 1000, guess = nil, &f : GSL::Function)
+    find_min?(x_lower, x_upper, eps, algorithm: algorithm, max_iter: max_iter, guess: guess, &f) || raise IterationsLimitExceeded.new("find_min didn't converge")
+  end
+end


### PR DESCRIPTION
This PR adds interface to `gsl_min_fminimizer_` functions.

Also, changes CI for Windows to static lib instead of dll (looks like static variables are not exported correctly in MSVC builds). It is still possible to build `cblas` dynamically to replace it with optimized implementation, but that's out of scope here.

Also due to the bug in `find_bracket` http://savannah.gnu.org/bugs/?45053 it adds reimplementation of `find_bracket` with proposed patch.