### PR TITLE
added Matrix#abs, made inv spec passing

### DIFF
--- a/spec/matrix_spec.cr
+++ b/spec/matrix_spec.cr
@@ -202,7 +202,7 @@ describe GSL::DenseMatrix do
       temp.shape.should eq({5, 5})
     end
   end
-  pending "#inverse" do
+  describe "#inverse" do
     it "should return the inverse of the input matrix" do
       tester = [
         [1.0, 0.6, 0.0],
@@ -214,7 +214,7 @@ describe GSL::DenseMatrix do
         [0.0, 2.0, -2.0],
         [0.0, -2.0, 3.0],
       ].to_matrix
-      tester.inverse.should eq target
+      tester.inverse.should be_close target, 1e-9
     end
   end
 end

--- a/spec/sparse_matrix_spec.cr
+++ b/spec/sparse_matrix_spec.cr
@@ -59,4 +59,15 @@ describe GSL::SparseMatrix do
       temp.non_zero.should eq 2
     end
   end
+  describe "#minmax" do
+    it "should return the minimum and maximun value of the matrix" do
+      temp = test_matrix.like
+      temp[0, 0] = 1
+      temp.minmax.should eq [0, 1]
+    end
+    it "should return 0 value for empty matrix" do
+      temp = test_matrix.like
+      temp.minmax.should eq [0, 0]
+    end
+  end
 end

--- a/src/gsl/base/matrix.cr
+++ b/src/gsl/base/matrix.cr
@@ -290,7 +290,10 @@ module GSL
     end
 
     def minmax
+      return [0.0, 0.0] if non_zero == 0
       LibGSL.gsl_spmatrix_minmax(@pointer, out min, out max)
+      min = 0.0 if min > 0.0
+      max = 0.0 if max < 0.0
       return [min, max]
     end
   end

--- a/src/gsl/base/matrix.cr
+++ b/src/gsl/base/matrix.cr
@@ -24,8 +24,6 @@ module GSL
       end
     end
 
-    # abstract def ==(m : Matrix)
-
     abstract def row(r : Int32 | Symbol) : Vector
     abstract def column(c : Int32 | Symbol) : Vector
     abstract def get(row, column) : Float64
@@ -44,6 +42,11 @@ module GSL
 
     # alias to transpose
     abstract def t : Matrix
+
+    # returns maximum norm of matrix
+    def abs
+      minmax.map(&.abs).max
+    end
   end
 
   class DenseMatrix < Matrix
@@ -168,7 +171,8 @@ module GSL
     end
 
     def minmax
-      [LibGSL.gsl_matrix_min(@pointer), LibGSL.gsl_matrix_max(@pointer)]
+      LibGSL.gsl_matrix_minmax(@pointer, out min, out max)
+      return [min, max]
     end
 
     def max_index
@@ -283,6 +287,11 @@ module GSL
 
     def finalize
       LibGSL.gsl_spmatrix_free(@pointer)
+    end
+
+    def minmax
+      LibGSL.gsl_spmatrix_minmax(@pointer, out min, out max)
+      return [min, max]
     end
   end
 end


### PR DESCRIPTION
I think simplest way to make pending `#inv` spec passing is to add `#abs` that returns floating value. Then `be_close` expectation would work for matrices. And easiest way to implement `#abs` is a matrix infinity norm.
I've also changed `minmax` to use minmax from GSL and added `minmax` to SparseMatrix.